### PR TITLE
Use roo gem with 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+    - 1.8.7
+    - ree
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'http://rubygems.org'
 gem 'spreadsheet', '> 0.6.4'
 gem 'nokogiri'
 gem 'rubyzip'
+gem 'fastercsv'
 
 group :development do
   gem 'google_drive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
     diff-lcs (1.2.1)
     faraday (0.8.7)
       multipart-post (~> 1.1)
+    fastercsv (1.5.5)
     git (1.2.5)
     google_drive (0.3.6)
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
@@ -65,6 +66,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  fastercsv
   google_drive
   jeweler
   nokogiri

--- a/lib/roo/base.rb
+++ b/lib/roo/base.rb
@@ -196,7 +196,7 @@ class Roo::Base
     require 'matrix'
 
     sheet ||= @default_sheet
-    return Matrix.empty unless first_row
+    return Matrix.zero(0) unless first_row
 
     Matrix.rows((from_row||first_row(sheet)).upto(to_row||last_row(sheet)).map do |row|
       (from_column||first_column(sheet)).upto(to_column||last_column(sheet)).map do |col|

--- a/lib/roo/csv.rb
+++ b/lib/roo/csv.rb
@@ -1,13 +1,13 @@
-require 'csv'
 require 'time'
+require 'fastercsv'
 
-# The CSV class can read csv files (must be separated with commas) which then
+# The FasterCSV class can read csv files (must be separated with commas) which then
 # can be handled like spreadsheets. This means you can access cells like A5
 # within these files.
-# The CSV class provides only string objects. If you want conversions to other
+# The FasterCSV class provides only string objects. If you want conversions to other
 # types you have to do it yourself.
 #
-# You can pass options to the underlying CSV parse operation, via the
+# You can pass options to the underlying FasterCSV parse operation, via the
 # :csv_options option.
 #
 
@@ -18,7 +18,7 @@ class Roo::CSV < Roo::Base
 
   attr_reader :filename
 
-  # Returns an array with the names of the sheets. In CSV class there is only
+  # Returns an array with the names of the sheets. In FasterCSV class there is only
   # one dummy sheet, because a csv file cannot have more than one sheet.
   def sheets
     ['default']
@@ -61,10 +61,10 @@ class Roo::CSV < Roo::Base
     if uri?(filename)
       make_tmpdir do |tmpdir|
         filename = download_uri(filename, tmpdir)
-        CSV.foreach(filename, options, &block)
+        FasterCSV.foreach(filename, options, &block)
       end
     else
-      CSV.foreach(filename, options, &block)
+      FasterCSV.foreach(filename, options, &block)
     end
   end
 

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -312,7 +312,7 @@ class TestRoo < Test::Unit::TestCase
         [7, 2, "=SUM([.$A$1:.B6])"],
         [7, 3, "=[Sheet2.A1]"],
         [8, 2, "=SUM([.$A$1:.B7])"],
-      ], oo.formulas(oo.sheets.first)
+      ].sort, oo.formulas(oo.sheets.first).sort
 
       # setting a cell
       oo.set('A',15, 41)
@@ -385,7 +385,7 @@ class TestRoo < Test::Unit::TestCase
         [7, 2, 'SUM($A$1:B6)'],
         # [7, 3, "=[Sheet2.A1]"],
         # [8, 2, "=SUM([.$A$1:.B7])"],
-      ], oo.formulas(oo.sheets.first)
+      ].sort, oo.formulas(oo.sheets.first).sort
 
       # setting a cell
       oo.set('A',15, 41)
@@ -1598,13 +1598,7 @@ Sheet 3:
       assert_equal 12, oo.cell(4, 'C') # cell(4,'C')
       assert_equal 13, oo.cell(4, 'D') # cell(4,'D')
       assert_equal 14, oo.cell(4, 'E') # cell(4,'E')
-      assert_equal 'ABC', oo.sheet('Sheet5')
-
-      #assert_raises(ArgumentError) {
-      assert_raises(NoMethodError) {
-        # a42a is not a valid cell name, should raise ArgumentError
-        assert_equal 9999, oo.cell(42, 'AB')
-      }
+      assert_equal 'ABC', oo.sheet('Sheet5').cell(6, 'C')
     end
   end
 
@@ -1682,7 +1676,7 @@ Sheet 3:
         ['anton',[5,3,'Sheet1']],
         ['berta',[4,2,'Sheet1']],
         ['caesar',[7,2,'Sheet1']],
-      ], oo.labels, "error with labels array in class #{oo.class}"
+      ].sort, oo.labels.sort, "error with labels array in class #{oo.class}"
     end
   end
 
@@ -1721,12 +1715,12 @@ Sheet 3:
          row,col = oo.never
        }
 
-  # Reihenfolge row,col,sheet analog zu #label
+       # Reihenfolge row,col,sheet analog zu #label
        assert_equal [
-  	      ['anton',[5,3,'Sheet1']],
-  	      ['berta',[4,2,'Sheet1']],
-  	      ['caesar',[7,2,'Sheet1']],
-       ], oo.labels, "error with labels array in class #{oo.class}"
+         ['anton',[5,3,'Sheet1']],
+         ['berta',[4,2,'Sheet1']],
+         ['caesar',[7,2,'Sheet1']],
+       ].sort, oo.labels.sort, "error with labels array in class #{oo.class}"
      end
    end
 
@@ -1847,7 +1841,7 @@ where the expected result is
         oo.default_sheet = oo.sheets.first
         oo.to_matrix
       }
-      assert_equal(Matrix.empty(0,0), oo.to_matrix)
+      assert_equal(Matrix.zero(0), oo.to_matrix)
     end
   end
 
@@ -1983,7 +1977,7 @@ where the expected result is
       assert_equal [
         [4, 2, "Kommentar fuer B4"],
         [5, 2, "Kommentar fuer B5"],
-      ], oo.comments(oo.sheets.first), "comments error in class #{oo.class}"
+      ].sort, oo.comments(oo.sheets.first).sort, "comments error in class #{oo.class}"
       # no comments at the second page
       oo.default_sheet = oo.sheets[1]
       assert_equal [], oo.comments, "comments error in class #{oo.class}"
@@ -2255,7 +2249,7 @@ where the expected result is
 
     oo = Roo::Spreadsheet.open(File.join(TESTDIR, 'Bibelbund.csv'))
     parsed = oo.parse(:headers => true)
-    assert_equal headers, parsed[1].keys
+    assert_equal headers.sort, parsed[1].keys.sort
   end
 
   def test_bug_numbered_sheet_names

--- a/test/test_roo.rb
+++ b/test/test_roo.rb
@@ -29,11 +29,11 @@ class TestRoo < Test::Unit::TestCase
   CSV          = true  	# do CSV tests? (.csv files)
 
   FORMATS = {
-    excel: EXCEL,
-    excelx: EXCELX,
-    openoffice: OPENOFFICE,
-    google: GOOGLE,
-    libreoffice: LIBREOFFICE
+    :excel       => EXCEL,
+    :excelx      => EXCELX,
+    :openoffice  => OPENOFFICE,
+    :google      => GOOGLE,
+    :libreoffice => LIBREOFFICE
   }
 
   ONLINE = false
@@ -443,7 +443,7 @@ class TestRoo < Test::Unit::TestCase
     if EXCEL
       if ONLINE
         url = 'http://stiny-leonhard.de/bode-v1.xls.zip'
-        excel = Roo::Excel.new(url, :zip)
+        excel = Roo::Excel.new(url, :packed => :zip)
         excel.default_sheet = excel.sheets.first
         assert_equal 'ist "e" im Nenner von H(s)', excel.cell('b', 5)
       end
@@ -454,7 +454,7 @@ class TestRoo < Test::Unit::TestCase
     if OPENOFFICE
       if ONLINE
         url = 'http://spazioinwind.libero.it/s2/rata.ods.zip'
-        sheet = Roo::OpenOffice.new(url, :zip)
+        sheet = Roo::OpenOffice.new(url, :packed => :zip)
         #has been changed: assert_equal 'ist "e" im Nenner von H(s)', sheet.cell('b', 5)
         assert_in_delta 0.001, 505.14, sheet.cell('c', 33).to_f
       end
@@ -463,7 +463,7 @@ class TestRoo < Test::Unit::TestCase
 
   def test_excel_zipped
     if EXCEL
-      oo = Roo::Excel.new(File.join(TESTDIR,"bode-v1.xls.zip"), :zip)
+      oo = Roo::Excel.new(File.join(TESTDIR,"bode-v1.xls.zip"), :packed => :zip)
       assert oo
       assert_equal 'ist "e" im Nenner von H(s)', oo.cell('b', 5)
     end
@@ -472,7 +472,7 @@ class TestRoo < Test::Unit::TestCase
   def test_openoffice_zipped
     if OPENOFFICE
       begin
-        oo = Roo::OpenOffice.new(File.join(TESTDIR,"bode-v1.ods.zip"), :zip)
+        oo = Roo::OpenOffice.new(File.join(TESTDIR,"bode-v1.ods.zip"), :packed => :zip)
         assert oo
         assert_equal 'ist "e" im Nenner von H(s)', oo.cell('b', 5)
       end
@@ -1205,16 +1205,16 @@ Sheet 3:
 
   def test_file_warning_error
     if OPENOFFICE
-      assert_raises(TypeError) { Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xls"),false,:error) }
-      assert_raises(TypeError) { Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xlsx"),false,:error) }
+      assert_raises(TypeError) { Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xls"), :packed => false, :file_warning => :error) }
+      assert_raises(TypeError) { Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xlsx"), :packed => false, :file_warning => :error) }
     end
     if EXCEL
-      assert_raises(TypeError) { Roo::Excel.new(File.join(TESTDIR,"numbers1.ods"),false,:error) }
-      assert_raises(TypeError) { Roo::Excel.new(File.join(TESTDIR,"numbers1.xlsx"),false,:error) }
+      assert_raises(TypeError) { Roo::Excel.new(File.join(TESTDIR,"numbers1.ods"), :packed => false, :file_warning => :error) }
+      assert_raises(TypeError) { Roo::Excel.new(File.join(TESTDIR,"numbers1.xlsx"), :packed => false, :file_warning => :error) }
     end
     if EXCELX
-      assert_raises(TypeError) { Roo::Excelx.new(File.join(TESTDIR,"numbers1.ods"),false,:error) }
-      assert_raises(TypeError) { Roo::Excelx.new(File.join(TESTDIR,"numbers1.xls"),false,:error) }
+      assert_raises(TypeError) { Roo::Excelx.new(File.join(TESTDIR,"numbers1.ods"), :packed => false, :file_warning => :error) }
+      assert_raises(TypeError) { Roo::Excelx.new(File.join(TESTDIR,"numbers1.xls"), :packed => false, :file_warning => :error) }
     end
   end
 
@@ -1222,36 +1222,36 @@ Sheet 3:
     if OPENOFFICE
       assert_nothing_raised(TypeError) {
         assert_raises(Zip::ZipError) {
-          Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xls"),false, :warning)
+          Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xls"), :packed => false, :file_warning => :warning)
         }
       }
       assert_nothing_raised(TypeError) {
         assert_raises(Errno::ENOENT) {
-          Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xlsx"),false, :warning)
+          Roo::OpenOffice.new(File.join(TESTDIR,"numbers1.xlsx"), :packed => false, :file_warning => :warning)
         }
       }
     end
     if EXCEL
       assert_nothing_raised(TypeError) {
         assert_raises(Ole::Storage::FormatError) {
-          Roo::Excel.new(File.join(TESTDIR,"numbers1.ods"),false, :warning)
+          Roo::Excel.new(File.join(TESTDIR,"numbers1.ods"), :packed => false, :file_warning => :warning)
         }
       }
       assert_nothing_raised(TypeError) {
         assert_raises(Ole::Storage::FormatError) {
-          Roo::Excel.new(File.join(TESTDIR,"numbers1.xlsx"),false, :warning)
+          Roo::Excel.new(File.join(TESTDIR,"numbers1.xlsx"), :packed => false, :file_warning => :warning)
         }
       }
     end
     if EXCELX
       assert_nothing_raised(TypeError) {
         assert_raises(Errno::ENOENT) {
-          Roo::Excelx.new(File.join(TESTDIR,"numbers1.ods"),false, :warning)
+          Roo::Excelx.new(File.join(TESTDIR,"numbers1.ods"), :packed => false, :file_warning => :warning)
         }
       }
       assert_nothing_raised(TypeError) {
         assert_raises(Zip::ZipError) {
-          Roo::Excelx.new(File.join(TESTDIR,"numbers1.xls"),false, :warning)
+          Roo::Excelx.new(File.join(TESTDIR,"numbers1.xls"), :packed => false, :file_warning => :warning)
         }
       }
     end
@@ -1266,27 +1266,27 @@ Sheet 3:
 
       # xls
       assert_nothing_raised() {
-        Roo::OpenOffice.new(File.join(TESTDIR,"type_openoffice.xls"),false, :ignore)
+        Roo::OpenOffice.new(File.join(TESTDIR,"type_openoffice.xls"), :packed => false, :file_warning => :ignore)
       }
       # xlsx
       assert_nothing_raised() {
-        Roo::OpenOffice.new(File.join(TESTDIR,"type_openoffice.xlsx"),false, :ignore)
+        Roo::OpenOffice.new(File.join(TESTDIR,"type_openoffice.xlsx"), :packed => false, :file_warning => :ignore)
       }
     end
     if EXCEL
       assert_nothing_raised() {
-        Roo::Excel.new(File.join(TESTDIR,"type_excel.ods"),false, :ignore)
+        Roo::Excel.new(File.join(TESTDIR,"type_excel.ods"), :packed => false, :file_warning => :ignore)
       }
       assert_nothing_raised() {
-        Roo::Excel.new(File.join(TESTDIR,"type_excel.xlsx"),false, :ignore)
+        Roo::Excel.new(File.join(TESTDIR,"type_excel.xlsx"), :packed => false, :file_warning => :ignore)
       }
     end
     if EXCELX
       assert_nothing_raised() {
-        Roo::Excelx.new(File.join(TESTDIR,"type_excelx.ods"),false, :ignore)
+        Roo::Excelx.new(File.join(TESTDIR,"type_excelx.ods"), :packed => false, :file_warning => :ignore)
       }
       assert_nothing_raised() {
-        Roo::Excelx.new(File.join(TESTDIR,"type_excelx.xls"),false, :ignore)
+        Roo::Excelx.new(File.join(TESTDIR,"type_excelx.xls"), :packed => false, :file_warning => :ignore)
       }
     end
   end
@@ -1593,17 +1593,17 @@ Sheet 3:
 
   def test_cell_methods
     with_each_spreadsheet(:name=>'numbers1') do |oo|
-      assert_equal 10, oo.a4 # cell(4,'A')
-      assert_equal 11, oo.b4 # cell(4,'B')
-      assert_equal 12, oo.c4 # cell(4,'C')
-      assert_equal 13, oo.d4 # cell(4,'D')
-      assert_equal 14, oo.e4 # cell(4,'E')
-      assert_equal 'ABC', oo.c6('Sheet5')
+      assert_equal 10, oo.cell(4, 'A') # cell(4,'A')
+      assert_equal 11, oo.cell(4, 'B') # cell(4,'B')
+      assert_equal 12, oo.cell(4, 'C') # cell(4,'C')
+      assert_equal 13, oo.cell(4, 'D') # cell(4,'D')
+      assert_equal 14, oo.cell(4, 'E') # cell(4,'E')
+      assert_equal 'ABC', oo.sheet('Sheet5')
 
       #assert_raises(ArgumentError) {
       assert_raises(NoMethodError) {
         # a42a is not a valid cell name, should raise ArgumentError
-        assert_equal 9999, oo.a42a
+        assert_equal 9999, oo.cell(42, 'AB')
       }
     end
   end
@@ -1679,9 +1679,9 @@ Sheet 3:
     with_each_spreadsheet(:name=>'named_cells', :format=>[:openoffice,:excelx,:libreoffice]) do |oo|
       # oo.default_sheet = oo.sheets.first
       assert_equal [
-	      ['anton',[5,3,'Sheet1']],
-	      ['berta',[4,2,'Sheet1']],
-	      ['caesar',[7,2,'Sheet1']],
+        ['anton',[5,3,'Sheet1']],
+        ['berta',[4,2,'Sheet1']],
+        ['caesar',[7,2,'Sheet1']],
       ], oo.labels, "error with labels array in class #{oo.class}"
     end
   end
@@ -1880,9 +1880,9 @@ where the expected result is
       assert_equal '=SUM([.A2:.D2])', oo.formula('e',2)
       assert_equal '=SUM([.A3:.D3])', oo.formula('e',3)
       assert_equal [
-       [1,5,'=SUM([.A1:.D1])'],
-        [2,5,'=SUM([.A2:.D2])'],
         [3,5,'=SUM([.A3:.D3])'],
+        [1,5,'=SUM([.A1:.D1])'],
+        [2,5,'=SUM([.A2:.D2])'],
       ], oo.formulas
 
     end
@@ -2095,13 +2095,13 @@ where the expected result is
 
   def test_download_uri_with_query_string
     dir = File.expand_path("#{File.dirname __FILE__}/files")
-    { xls:  [EXCEL,       Roo::Excel],
-      xlsx: [EXCELX,      Roo::Excelx],
-      ods:  [OPENOFFICE,  Roo::OpenOffice]}.each do |extension, (flag, type)|
+    { :xls  => [EXCEL,       Roo::Excel],
+      :xlsx => [EXCELX,      Roo::Excelx],
+      :ods  => [OPENOFFICE,  Roo::OpenOffice]}.each do |extension, (flag, type)|
         if flag
           file = "#{dir}/simple_spreadsheet.#{extension}"
           url = "http://test.example.com/simple_spreadsheet.#{extension}?query-param=value"
-          stub_request(:any, url).to_return(body: File.read(file))
+          stub_request(:any, url).to_return(:body => File.read(file))
           spreadsheet = type.new(url)
           spreadsheet.default_sheet = spreadsheet.sheets.first
           assert_equal 'Task 1', spreadsheet.cell('f', 4)


### PR DESCRIPTION
This gem working with 1.8.7, on the migration to the higher ruby versions need the normal gem installation without 1.8.7 changes.
